### PR TITLE
BetterRuinsv0.3.2

### DIFF
--- a/assets/betterruins/patches/modconfig/overallspawnchance.json
+++ b/assets/betterruins/patches/modconfig/overallspawnchance.json
@@ -17,5 +17,28 @@
         "modid": "strspawnchances", "invert": true
       }
     ]
+  },
+
+
+
+
+
+
+  //
+  //
+  // This value affects all villages in the whole game!
+  //
+  //
+  {
+    "op": "replace",
+    "path": "/chanceMultiplier",
+    "value": 0.035, // # default = 0.035; vanilla = 0.05; 33% = 0.10; 66% = 0.20; 150% = 0.45; 200% = 0.60; 300% = 0.90
+    "file": "game:worldgen/villages.json",
+    "side": "Server",
+    "dependsOn": [
+      {
+        "modid": "strspawnchances", "invert": true
+      }
+    ]
   }
 ]

--- a/assets/betterruins/patches/modconfig/overallspawnchance.json
+++ b/assets/betterruins/patches/modconfig/overallspawnchance.json
@@ -32,7 +32,7 @@
   {
     "op": "replace",
     "path": "/chanceMultiplier",
-    "value": 0.035, // # default = 0.035; vanilla = 0.05; 33% = 0.10; 66% = 0.20; 150% = 0.45; 200% = 0.60; 300% = 0.90
+    "value": 0.035, // # default = 0.035; vanilla = 0.05; 33% = 0.012; 66% = 0.023; 150% = 0.053; 200% = 0.070; 300% = 0.11
     "file": "game:worldgen/villages.json",
     "side": "Server",
     "dependsOn": [

--- a/assets/betterruins/patches/others/randomizers/stackrandomizers-gear.json
+++ b/assets/betterruins/patches/others/randomizers/stackrandomizers-gear.json
@@ -17,7 +17,7 @@
       "type": "item",
       "code": "metalbit-silver",
       "quantity": {
-        "avg": 6,
+        "avg": 4,
         "var": 2
       },
       "chance": 2
@@ -32,8 +32,8 @@
       "type": "item",
       "code": "metalbit-gold",
       "quantity": {
-        "avg": 5,
-        "var": 3
+        "avg": 3,
+        "var": 2
       },
       "chance": 2
     },
@@ -223,6 +223,21 @@
       "type": "item",
       "code": "betterruins:br-schematic-road",
       "chance": 2
+    },
+    "file": "game:itemtypes/meta/stackrandomizer.json",
+    "side": "Server"
+  },
+  {
+    "op": "add",
+    "path": "/attributesByType/*-gear/stacks/-",
+    "value": {
+      "type": "item",
+      "code": "game:stick",
+      "chance": 100,
+      "quantity": {
+        "avg": 7,
+        "var": 6
+      }
     },
     "file": "game:itemtypes/meta/stackrandomizer.json",
     "side": "Server"

--- a/assets/betterruins/patches/others/randomizers/stackrandomizers-ingots.json
+++ b/assets/betterruins/patches/others/randomizers/stackrandomizers-ingots.json
@@ -103,5 +103,20 @@
     },
     "file": "game:itemtypes/meta/stackrandomizer.json",
     "side": "Server"
+  },
+  {
+    "op": "add",
+    "path": "/attributesByType/*-ingot/stacks/-",
+    "value": {
+      "type": "item",
+      "code": "game:stick",
+      "chance": 40,
+      "quantity": {
+        "avg": 7,
+        "var": 6
+      }
+    },
+    "file": "game:itemtypes/meta/stackrandomizer.json",
+    "side": "Server"
   }
 ]

--- a/assets/betterruins/recipes/grid/schematic-stone/stone.json
+++ b/assets/betterruins/recipes/grid/schematic-stone/stone.json
@@ -128,7 +128,7 @@
         "ingredients": {
             "X": {type: "Item", code: "br-schematic-stone" },
             "P": {type: "Item", code: "game:chisel-*" , "isTool": true},
-            "B": {type: "Block", code: "game:rockpolished-*", name: "rock", skipVariants: ["whitemarble", "suevite", "redmarble", "kimberlite", "greenmarble", "andesite", "chalk", "conglomerate", "shale", "basalt", "phyllite", "bauxite"]}
+            "B": {type: "Block", code: "game:rockpolished-*", name: "rock", skipVariants: ["whitemarble", "suevite", "redmarble", "kimberlite", "greenmarble", "andesite", "chalk", "conglomerate", "shale", "basalt", "phyllite", "bauxite", "obsidian"]}
         },
         "width": 1,
         "height": 3,

--- a/assets/game/itemtypes/meta/stackrandomizer-betterruins.json
+++ b/assets/game/itemtypes/meta/stackrandomizer-betterruins.json
@@ -267,7 +267,16 @@
           "type": "item",
           "code": "armor-legs-tailored-yellow-linen",
           "chance": 100
-        }
+        },
+		{
+			"type": "item",
+			"code": "game:stick",
+			"chance": 1200,
+			"quantity": {
+			  "avg": 7,
+			  "var": 6
+			}
+		  }
       ]
 		},
 		
@@ -2115,7 +2124,7 @@
 					"avg": 4,
 					"var": 2
 				  },
-				  "chance": 50
+				  "chance": 120
 				},
 				{
 				  "type": "item",
@@ -2124,7 +2133,7 @@
 					"avg": 4,
 					"var": 2
 				  },
-				  "chance": 50
+				  "chance": 120
 				},
 				{
 				  "type": "item",

--- a/modinfo.json
+++ b/modinfo.json
@@ -4,9 +4,9 @@
   "name": "BetterRuins",
   "description" : "Adds a lot of structures to the worldgen over and underground.\nBuilderteam: Dampus, SamGrey, StAdrian, Bellcross, Djvirus, Bodlacek, Catnoir, Par, Rowly, Vilderos, Virrnogamr,\nQuentinQP, OnBean, Boitameu, LordJarJar, Yerts, XurxoMF, Marlim, NeonScorpion\nTranslators: Xandoria, macoto_hino, yanazake, Knave2000, Grigoriewich, Jefferzon, Srloboalbino, Vilderos",
   "authors": ["NiclAss"],
-  "version": "0.3.1",
+  "version": "0.3.2",
   "side": "Universal",
   "dependencies": {
-    "game": "1.19.3"
+    "game": "1.19.0"
   }
 }


### PR DESCRIPTION
- Fix: Fixed a warning/error caused by betterruins and bricklayers
- Tweak: Added modifier to configure spawn chance of all villages
- Tweak: Reduced villages by 20%
- Tweak: Reduced the following loot (gears -20%, ingots -25%; armor -30%; mechanical parts -30%)(fyi the loot config mod will get a revive soon)
- Fix: Made this mod compatible with pre 1.19.3